### PR TITLE
Remove hard-coded path to the HSrts

### DIFF
--- a/call-haskell-from-anything.cabal
+++ b/call-haskell-from-anything.cabal
@@ -66,5 +66,9 @@ executable call-haskell-from-anything.so
   -- For building TemplateHaskell with cabal and -dynamic, we have to disable -dynamic sometimes
     -no-hs-main -fPIC -shared -dynamic
   --  -no-hs-main
-  -- TODO remove hardcoded path somehow
-  ld-options: -shared /usr/lib/ghc/libHSrts-ghc7.6.3.so
+  ld-options: -shared
+
+  -- Change the following line to match your GHC version. For example,
+  -- using GHC 7.8.2, the extra-libraries should read,
+  -- "HSrts-ghc7.8.2".
+  extra-libraries: HSrts-ghc7.6.3


### PR DESCRIPTION
I did some googling, and this worked for me in the cabal file using GHC 7.8.2 locally. You should probably try it on GHC 7.6.3 before merging. Just figured I'd submit this PR since I noticed the TODO and found a solution that worked for me. I haven't tried on 7.6.3 yet.

On a related note, I was wondering if you'd be willing to consider a PR adding travis for this repo? It seems like it would be useful to have this built automatically by a couple of GHC versions at least. I'd be willing to try to put something together based on travis files that I have for other projects if you'd consider it.
