### PR TITLE
Python 2 & 3

### DIFF
--- a/call-haskell-from-anything.cabal
+++ b/call-haskell-from-anything.cabal
@@ -18,8 +18,8 @@ bug-reports:   https://github.com/nh2/call-haskell-from-anything/issues
 
 
 extra-source-files:
-  configure
-  detect-ghc-buildinfo.py
+    configure
+  , detect-ghc-buildinfo.py
 
 
 source-repository head

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 # Pass all arguments that cabal passes us to the python script.
-python2 detect-ghc-buildinfo.py $@
+python detect-ghc-buildinfo.py $@

--- a/detect-ghc-buildinfo.py
+++ b/detect-ghc-buildinfo.py
@@ -14,9 +14,9 @@ args, _unknown = parser.parse_known_args()  # ignore unknown arguments from caba
 ghc_binary = args.with_compiler
 
 
-print "Determining GHC version:",
+print("Determining GHC version:")
 ghc_version = subprocess.check_output([ghc_binary, "--numeric-version"]).strip()
-print ghc_version
+print(ghc_version)
 
 
 with open("call-haskell-from-anything.buildinfo", "w") as f:


### PR DESCRIPTION
configure fails when trying to use `python2`

I switched to using `python` and updated the script to work with 2 & 3

